### PR TITLE
gf_gen2_consolidation_triggers: support binding pubsub trigger to an …

### DIFF
--- a/gf_gen2_consolidation_triggers/main.tf
+++ b/gf_gen2_consolidation_triggers/main.tf
@@ -202,21 +202,33 @@ resource "google_storage_bucket_object" "archive" {
 }
 
 ## Pub/Sub Topic
+# Created only when no external topic is supplied via var.pubsub_topic.
 resource "google_pubsub_topic" "topic" {
-  name = "${var.name}_trigger_topic"
+  count      = var.pubsub_topic == "" ? 1 : 0
+  name       = "${var.name}_trigger_topic"
   depends_on = [google_project_service.pubsub_api]
+}
+
+# Keep existing deployments (pre-count) in place.
+moved {
+  from = google_pubsub_topic.topic
+  to   = google_pubsub_topic.topic[0]
+}
+
+locals {
+  trigger_topic_id = var.pubsub_topic != "" ? var.pubsub_topic : google_pubsub_topic.topic[0].id
 }
 
 ## Cloud Scheduler Job
 resource "google_cloud_scheduler_job" "job" {
-  count       = var.instantiate_scheduler ? 1 : 0
+  count       = var.instantiate_scheduler && var.pubsub_topic == "" ? 1 : 0
   name        = "${var.name}_scheduler"
   description = "A schedule for triggering the function"
   schedule    = var.schedule
   region      = var.function_region
 
   pubsub_target {
-    topic_name = google_pubsub_topic.topic.id
+    topic_name = google_pubsub_topic.topic[0].id
     data       = base64encode("test")
   }
   depends_on = [
@@ -382,6 +394,7 @@ resource "google_cloudfunctions2_function" "pubsub_function" {
   service_config {
     max_instance_count             = var.max_instances
     min_instance_count             = var.min_instances
+    max_instance_request_concurrency = var.max_instance_request_concurrency
     available_memory               = var.available_memory
     available_cpu                  = var.available_cpu
     timeout_seconds                = var.timeout
@@ -398,7 +411,7 @@ resource "google_cloudfunctions2_function" "pubsub_function" {
       retry_policy = "RETRY_POLICY_DO_NOT_RETRY"
 
       trigger_region = var.region
-      pubsub_topic   = google_pubsub_topic.topic.id
+      pubsub_topic   = local.trigger_topic_id
     }
 
   depends_on = [

--- a/gf_gen2_consolidation_triggers/outputs.tf
+++ b/gf_gen2_consolidation_triggers/outputs.tf
@@ -14,19 +14,19 @@ output "cloud_function_service_account_email" {
 }
 
 output "pubsub_topic_name" {
-  description = "The name of the Pub/Sub topic created."
-  value       = google_pubsub_topic.topic.name
+  description = "The name of the Pub/Sub topic created, or the externally supplied topic ID."
+  value       = coalesce(one(google_pubsub_topic.topic[*].name), var.pubsub_topic)
 }
 
 # Handle the count parameter for Cloud Scheduler Job
 output "cloud_scheduler_job_name" {
   description = "The name of the Cloud Scheduler job created."
-  value       = var.instantiate_scheduler ? google_cloud_scheduler_job.job[0].name : "Not created"
+  value       = length(google_cloud_scheduler_job.job) > 0 ? google_cloud_scheduler_job.job[0].name : "Not created"
 }
 
 output "cloud_scheduler_job_schedule" {
   description = "The schedule of the Cloud Scheduler job."
-  value       = var.instantiate_scheduler ? google_cloud_scheduler_job.job[0].schedule : "Not created"
+  value       = length(google_cloud_scheduler_job.job) > 0 ? google_cloud_scheduler_job.job[0].schedule : "Not created"
 }
 
 output "archive_file_md5" {

--- a/gf_gen2_consolidation_triggers/variables.tf
+++ b/gf_gen2_consolidation_triggers/variables.tf
@@ -150,3 +150,9 @@ variable "max_instance_request_concurrency" {
   type        = number
   default     = 80
 }
+
+variable "pubsub_topic" {
+  description = "ID of an existing Pub/Sub topic to bind the trigger to (only relevant for trigger_type = \"pubsub\"). If empty, the module creates its own <name>_trigger_topic. When set, no topic or scheduler is created by this module."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
…external topic

- new optional var pubsub_topic: when set, the module creates no topic or scheduler and binds the pubsub function trigger to the supplied topic ID
- moved block keeps existing deployments in place now that the topic has count
- pubsub function now honours max_instance_request_concurrency
- outputs made robust for the conditional topic/scheduler