### PR TITLE
gf_gen2_consolidation_triggers: optional service_account_id and trigg…

### DIFF
--- a/gf_gen2_consolidation_triggers/main.tf
+++ b/gf_gen2_consolidation_triggers/main.tf
@@ -97,7 +97,7 @@ resource "google_project_iam_member" "token_creator_access" {
 
 ## Create and configure service account
 resource "google_service_account" "account" {
-  account_id   = substr(lower(replace("gcf-${var.name}", "_", "-")), 0, 30)
+  account_id   = var.service_account_id != "" ? var.service_account_id : substr(lower(replace("gcf-${var.name}", "_", "-")), 0, 30)
   display_name = "Execution Service Account - used for both the cloud function and eventarc trigger in the test"
 }
 
@@ -410,7 +410,7 @@ resource "google_cloudfunctions2_function" "pubsub_function" {
       event_type   = "google.cloud.pubsub.topic.v1.messagePublished"
       retry_policy = "RETRY_POLICY_DO_NOT_RETRY"
 
-      trigger_region = var.region
+      trigger_region = var.trigger_region != "" ? var.trigger_region : var.region
       pubsub_topic   = local.trigger_topic_id
     }
 

--- a/gf_gen2_consolidation_triggers/variables.tf
+++ b/gf_gen2_consolidation_triggers/variables.tf
@@ -156,3 +156,20 @@ variable "pubsub_topic" {
   type        = string
   default     = ""
 }
+
+variable "service_account_id" {
+  description = "Custom account_id for the service account created for the function. Defaults to \"gcf-<name>\" truncated to the 30-character limit; set this when truncation would collide across environments sharing a project."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.service_account_id == "" || can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.service_account_id))
+    error_message = "service_account_id must be 6-30 characters, lowercase letters, digits and hyphens, starting with a letter."
+  }
+}
+
+variable "trigger_region" {
+  description = "Region of the Eventarc trigger for trigger_type = \"pubsub\". Defaults to var.region. Set this when an existing trigger lives in a different region than the function."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
…er_region

- service_account_id overrides the derived gcf-<name> account id, which truncates at 30 characters and can collide across environments sharing a project
- trigger_region overrides the pubsub Eventarc trigger region when an existing trigger lives in a different region than the function