### PR TITLE
cloud_run_job: wire environment_variables map into the container env

### DIFF
--- a/cloud_run_job/main.tf
+++ b/cloud_run_job/main.tf
@@ -161,8 +161,10 @@ resource "google_cloud_run_v2_job" "job" {
       containers {
         image = var.image
 
+        # Merge both env variable formats: the environment list(map) and the
+        # environment_variables map, which was previously declared but ignored.
         dynamic "env" {
-          for_each = var.environment
+          for_each = concat(var.environment, [for k, v in var.environment_variables : { name = k, value = v }])
           content {
             name  = env.value.name
             value = env.value.value


### PR DESCRIPTION
The environment_variables variable was declared but never referenced, so callers passing it deployed jobs without any env vars. Its entries are now merged with the environment list into the env block.